### PR TITLE
⚡ Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Many ingress controllers require ArgoCD's API server be run with TLS disabled[^2
 |------|-------------|:----:|:-----:|:-----:|
 | release_name | Helm release name | string | `argocd` | no |
 | namespace | Namespace to install ArgoCD chart into (created if non-existent on target cluster) | string | `argocd` | no |
-| argocd_chart_version | Version of ArgoCD chart to install | string | `5.23.5` | no |
+| argocd_chart_version | Version of ArgoCD chart to install | string | `5.27.1` | no |
 | timeout_seconds | Helm chart deployment can sometimes take longer than the default 5 minutes. Set a custom timeout (secs) | number | `800` | no |
 | admin_password | Default Admin password | string | empty | no |
 | insecure | Disable TLS on the ArogCD API Server? | bool | `false` | no |

--- a/chart.tf
+++ b/chart.tf
@@ -16,12 +16,12 @@ resource "helm_release" "argocd" {
 
   set_sensitive {
     name  = "configs.secret.argocdServerAdminPassword"
-    value = local.default_password
+    value = var.admin_password == "" ? "" : bcrypt(var.admin_password)
   }
 
   set {
-    name  = "server.extraArgs"
-    value = var.insecure == false ? "" : "{--insecure}"
+    name  = "configs.params.server\\.insecure"
+    value = var.insecure == false ? false : true
   }
 
   set {

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -9,7 +9,7 @@ This example illustrates how to use the `terraform-kubernetes-argocd` module.
 |------|-------------|:----:|:-----:|:-----:|
 | release_name | Helm release name | string | `argocd` | no |
 | namespace | Namespace to install ArgoCD chart into (created if non-existent on target cluster) | string | `argocd` | no |
-| argocd_chart_version | Version of ArgoCD chart to install | string | `5.23.5` | no |
+| argocd_chart_version | Version of ArgoCD chart to install | string | `5.27.1` | no |
 | timeout_seconds | Helm chart deployment can sometimes take longer than the default 5 minutes. Set a custom timeout (secs) | number | `800` | no |
 | admin_password | Default Admin password | string | empty | no |
 | insecure | Disable TLS on the ArogCD API Server? | bool | `false` | no |

--- a/examples/vault_plugin/README.md
+++ b/examples/vault_plugin/README.md
@@ -9,7 +9,7 @@ This example illustrates how to use the `terraform-kubernetes-argocd` module to 
 |------|-------------|:----:|:-----:|:-----:|
 | release_name | Helm release name | string | `argocd` | no |
 | namespace | Namespace to install ArgoCD chart into (created if non-existent on target cluster) | string | `argocd` | no |
-| argocd_chart_version | Version of ArgoCD chart to install | string | `5.23.5` | no |
+| argocd_chart_version | Version of ArgoCD chart to install | string | `5.27.1` | no |
 | timeout_seconds | Helm chart deployment can sometimes take longer than the default 5 minutes. Set a custom timeout (secs) | number | `800` | no |
 | admin_password | Default Admin password | string | empty | no |
 | insecure | Disable TLS on the ArogCD API Server? | bool | `false` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  default_password = var.admin_password == "" ? "" : bcrypt(var.admin_password)
-}

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "namespace" {
 variable "argocd_chart_version" {
   description = "Version of ArgoCD chart to install"
   type        = string
-  default     = "5.23.5" # See https://artifacthub.io/packages/helm/argo/argo-cd for latest version(s)
+  default     = "5.27.1" # See https://artifacthub.io/packages/helm/argo/argo-cd for latest version(s)
 }
 
 # Helm chart deployment can sometimes take longer than the default 5 minutes
@@ -42,6 +42,6 @@ variable "enable_dex" {
 
 variable "insecure" {
   type        = bool
-  description = "Disable TLS on the ArogCD API Server? (adds the --insecure flag to the argocd-server command)"
+  description = "Disable TLS on the ArogCD API Server?"
   default     = false
 }


### PR DESCRIPTION
⚡ update deprecated `server.extraArgs."--insecure"` option to `configs.params.server.insecure` (Fix for issue #16)

⚡ update default chart version to `5.27.1` (Argo CD `v2.6.6`)